### PR TITLE
Fixed 2

### DIFF
--- a/phpQuery.php
+++ b/phpQuery.php
@@ -187,6 +187,7 @@ class DOMDocumentWrapper {
 			$this->root = $this->document;
 			$this->charset = $this->document->encoding;
 			// TODO isDocumentFragment
+			$loaded = true;
 		} else {
 			$loaded = $this->loadMarkup($markup);
 		}

--- a/phpQuery.php
+++ b/phpQuery.php
@@ -2169,18 +2169,20 @@ class phpQueryObject
 								return null;'),
 						new CallbackParam(), $param
 					);
-				else if (mb_strlen($param) > 1 && $param{1} == 'n')
+				else if (mb_strlen($param) > 1 && preg_match('/^(\d*)n([-+]?)(\d*)/', $param) === 1)
 					// an+b
 					$mapped = $this->map(
 						create_function('$node, $param',
 							'$prevs = pq($node)->prevAll()->size();
 							$index = 1+$prevs;
-							$b = mb_strlen($param) > 3
-								? $param{3}
-								: 0;
-							$a = $param{0};
-							if ($b && $param{2} == "-")
-								$b = -$b;
+
+							preg_match("/^(\d*)n([-+]?)(\d*)/", $param, $matches);
+ 							$a = intval($matches[1]);
+ 							$b = intval($matches[3]);
+ 							if( $matches[2] === "-" ) {
+ 							    $b = -$b;
+ 							}
+
 							if ($a > 0) {
 								return ($index-$b)%$a == 0
 									? $node


### PR DESCRIPTION
Fix crash when loading a DOMDocument node ($loaded not initialised).
Fix nth-child implementation:
The previous nth-child('an+b') implementation could only have a and b values that were single digit (eg
 5n-7).  Patterns like 13n+14 were not supported, and were interpreted as nth-child('13').
