### PR TITLE
create_function() has been deprecated since PHP 7.2

### DIFF
--- a/phpQuery.php
+++ b/phpQuery.php
@@ -2084,16 +2084,18 @@ class phpQueryObject
 			break;
 			case 'parent':
 				$this->elements = $this->map(
-					create_function('$node', '
+					function ($node) {
 						return $node instanceof DOMELEMENT && $node->childNodes->length
-							? $node : null;')
+							? $node : null;
+					}
 				)->elements;
 			break;
 			case 'empty':
 				$this->elements = $this->map(
-					create_function('$node', '
+					function ($node) {
 						return $node instanceof DOMELEMENT && $node->childNodes->length
-							? null : $node;')
+							? null : $node;
+					}
 				)->elements;
 			break;
 			case 'disabled':
@@ -2106,19 +2108,21 @@ class phpQueryObject
 			break;
 			case 'enabled':
 				$this->elements = $this->map(
-					create_function('$node', '
-						return pq($node)->not(":disabled") ? $node : null;')
+					function ($node) {
+						return pq($node)->not(":disabled") ? $node : null;
+					}
 				)->elements;
 			break;
 			case 'header':
 				$this->elements = $this->map(
-					create_function('$node',
-						'$isHeader = isset($node->tagName) && in_array($node->tagName, array(
+					function ($node) {
+						$isHeader = isset($node->tagName) && in_array($node->tagName, array(
 							"h1", "h2", "h3", "h4", "h5", "h6", "h7"
 						));
 						return $isHeader
 							? $node
-							: null;')
+							: null;
+					}
 				)->elements;
 //				$this->elements = $this->map(
 //					create_function('$node', '$node = pq($node);
@@ -2135,18 +2139,23 @@ class phpQueryObject
 			break;
 			case 'only-child':
 				$this->elements = $this->map(
-					create_function('$node',
-						'return pq($node)->siblings()->size() == 0 ? $node : null;')
+					function ($node) {
+						return pq($node)->siblings()->size() == 0 ? $node : null;
+					}
 				)->elements;
 			break;
 			case 'first-child':
 				$this->elements = $this->map(
-					create_function('$node', 'return pq($node)->prevAll()->size() == 0 ? $node : null;')
+					function ($node) {
+						return pq($node)->prevAll()->size() == 0 ? $node : null;
+					}
 				)->elements;
 			break;
 			case 'last-child':
 				$this->elements = $this->map(
-					create_function('$node', 'return pq($node)->nextAll()->size() == 0 ? $node : null;')
+					function ($node) {
+						return pq($node)->nextAll()->size() == 0 ? $node : null;
+					}
 				)->elements;
 			break;
 			case 'nth-child':
@@ -2159,21 +2168,22 @@ class phpQueryObject
 				// :nth-child(index/even/odd/equation)
 				if ($param == 'even' || $param == 'odd')
 					$mapped = $this->map(
-						create_function('$node, $param',
-							'$index = pq($node)->prevAll()->size()+1;
+						function ($node, $param) {
+							$index = pq($node)->prevAll()->size()+1;
 							if ($param == "even" && ($index%2) == 0)
 								return $node;
 							else if ($param == "odd" && $index%2 == 1)
 								return $node;
 							else
-								return null;'),
+								return null;
+						},
 						new CallbackParam(), $param
 					);
 				else if (mb_strlen($param) > 1 && preg_match('/^(\d*)n([-+]?)(\d*)/', $param) === 1)
 					// an+b
 					$mapped = $this->map(
-						create_function('$node, $param',
-							'$prevs = pq($node)->prevAll()->size();
+						function ($node, $param) {
+							$prevs = pq($node)->prevAll()->size();
 							$index = 1+$prevs;
 
 							preg_match("/^(\d*)n([-+]?)(\d*)/", $param, $matches);
@@ -2208,20 +2218,21 @@ class phpQueryObject
 //								return ($index-$b)%$a == 0
 //									? $node
 //									: null;
-							'),
+						},
 						new CallbackParam(), $param
 					);
 				else
 					// index
 					$mapped = $this->map(
-						create_function('$node, $index',
-							'$prevs = pq($node)->prevAll()->size();
+						function ($node, $index) {
+							$prevs = pq($node)->prevAll()->size();
 							if ($prevs && $prevs == $index-1)
 								return $node;
 							else if (! $prevs && $index == 1)
 								return $node;
 							else
-								return null;'),
+								return null;
+						},
 						new CallbackParam(), $param
 					);
 				$this->elements = $mapped->elements;
@@ -4771,15 +4782,15 @@ abstract class phpQuery {
 			while (preg_match($regex, $content))
 				$content = preg_replace_callback(
 					$regex,
-					create_function('$m',
-						'return $m[1].$m[2].$m[3]."<?php "
+					function ($m) {
+						return $m[1].$m[2].$m[3]."<?php "
 							.str_replace(
 								array("%20", "%3E", "%09", "&#10;", "&#9;", "%7B", "%24", "%7D", "%22", "%5B", "%5D"),
-								array(" ", ">", "	", "\n", "	", "{", "$", "}", \'"\', "[", "]"),
+								array(" ", ">", "	", "\n", "	", "{", "$", "}", '"', "[", "]"),
 								htmlspecialchars_decode($m[4])
 							)
-							." ?>".$m[5].$m[2];'
-					),
+							." ?>".$m[5].$m[2];
+					},
 					$content
 				);
 		return $content;

--- a/phpQuery.php
+++ b/phpQuery.php
@@ -281,7 +281,7 @@ class DOMDocumentWrapper {
 		// @see http://www.w3.org/International/O-HTTP-charset
 		if (! $documentCharset) {
 			$documentCharset = 'ISO-8859-1';
-			$addDocumentCharset = true;	
+			$addDocumentCharset = true;
 		}
 		// Should be careful here, still need 'magic encoding detection' since lots of pages have other 'default encoding'
 		// Worse, some pages can have mixed encodings... we'll try not to worry about that
@@ -568,7 +568,7 @@ class DOMDocumentWrapper {
 //					if ($fake === false)
 //						throw new Exception("Error loading documentFragment markup");
 //					else
-//						$return = array_merge($return, 
+//						$return = array_merge($return,
 //							$this->import($fake->root->childNodes)
 //						);
 //				} else {
@@ -970,24 +970,24 @@ interface ICallbackNamed {
 }
 /**
  * Callback class introduces currying-like pattern.
- * 
+ *
  * Example:
  * function foo($param1, $param2, $param3) {
  *   var_dump($param1, $param2, $param3);
  * }
- * $fooCurried = new Callback('foo', 
- *   'param1 is now statically set', 
+ * $fooCurried = new Callback('foo',
+ *   'param1 is now statically set',
  *   new CallbackParam, new CallbackParam
  * );
  * phpQuery::callbackRun($fooCurried,
  * 	array('param2 value', 'param3 value'
  * );
- * 
- * Callback class is supported in all phpQuery methods which accepts callbacks. 
+ *
+ * Callback class is supported in all phpQuery methods which accepts callbacks.
  *
  * @link http://code.google.com/p/phpquery/wiki/Callbacks#Param_Structures
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
- * 
+ *
  * @TODO??? return fake forwarding function created via create_function
  * @TODO honor paramStructure
  */
@@ -996,7 +996,7 @@ class Callback
 	public $callback = null;
 	public $params = null;
 	protected $name;
-	public function __construct($callback, $param1 = null, $param2 = null, 
+	public function __construct($callback, $param1 = null, $param2 = null,
 			$param3 = null) {
 		$params = func_get_args();
 		$params = array_slice($params, 1);
@@ -1025,11 +1025,11 @@ class Callback
 }
 /**
  * Shorthand for new Callback(create_function(...), ...);
- * 
+ *
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
  */
 class CallbackBody extends Callback {
-	public function __construct($paramList, $code, $param1 = null, $param2 = null, 
+	public function __construct($paramList, $code, $param1 = null, $param2 = null,
 			$param3 = null) {
 		$params = func_get_args();
 		$params = array_slice($params, 2);
@@ -1039,7 +1039,7 @@ class CallbackBody extends Callback {
 }
 /**
  * Callback type which on execution returns reference passed during creation.
- * 
+ *
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
  */
 class CallbackReturnReference extends Callback
@@ -1061,7 +1061,7 @@ class CallbackReturnReference extends Callback
 }
 /**
  * Callback type which on execution returns value passed during creation.
- * 
+ *
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
  */
 class CallbackReturnValue extends Callback
@@ -1088,7 +1088,7 @@ class CallbackReturnValue extends Callback
 }
 /**
  * CallbackParameterToReference can be used when we don't really want a callback,
- * only parameter passed to it. CallbackParameterToReference takes first 
+ * only parameter passed to it. CallbackParameterToReference takes first
  * parameter's value and passes it to reference.
  *
  * @author Tobiasz Cudnik <tobiasz.cudnik/gmail.com>
@@ -1096,7 +1096,7 @@ class CallbackReturnValue extends Callback
 class CallbackParameterToReference extends Callback {
 	/**
 	 * @param $reference
-	 * @TODO implement $paramIndex; 
+	 * @TODO implement $paramIndex;
 	 * param index choose which callback param will be passed to reference
 	 */
 	public function __construct(&$reference){
@@ -2997,7 +2997,7 @@ class phpQueryObject
 	}
 	/**
 	 * Enter description here...
-	 * 
+	 *
 	 * @param $code
 	 * @return unknown_type
 	 */
@@ -3008,7 +3008,7 @@ class phpQueryObject
 	}
 	/**
 	 * Enter description here...
-	 * 
+	 *
 	 * @param $code
 	 * @return unknown_type
 	 */
@@ -4063,7 +4063,7 @@ class phpQueryObject
 	}
 	/**
 	 * Enter description here...
-	 * 
+	 *
 	 * @param <type> $key
 	 * @param <type> $value
 	 */
@@ -4080,7 +4080,7 @@ class phpQueryObject
 	}
 	/**
 	 * Enter description here...
-	 * 
+	 *
 	 * @param <type> $key
 	 */
 	public function removeData($key) {
@@ -4421,8 +4421,8 @@ if (!function_exists('mb_substr_count'))
  */
 abstract class phpQuery {
 	/**
-	 * XXX: Workaround for mbstring problems 
-	 * 
+	 * XXX: Workaround for mbstring problems
+	 *
 	 * @var bool
 	 */
 	public static $mbstringSupport = true;


### PR DESCRIPTION
[Anonymous function](http://php.net/manual/en/functions.anonymous.php) is introduced in PHP 5.3.0 which just satisfies [composer.json](https://github.com/jae-jae/phpQuery-single/blob/master/composer.json#L7) in this project.

Fixes: https://github.com/jae-jae/phpQuery-single/issues/4

However, [this](https://github.com/jae-jae/phpQuery-single/blob/master/phpQuery.php#L1036) line is not fixed here (which may need to use `eval()`). But the class `CallbackBody` seems not to be used in this project.